### PR TITLE
fix: Have tests clean up temp files

### DIFF
--- a/host/src/test/java/org/area515/resinprinter/security/KeystoreSecurityTest.java
+++ b/host/src/test/java/org/area515/resinprinter/security/KeystoreSecurityTest.java
@@ -49,9 +49,11 @@ public class KeystoreSecurityTest {
 	@BeforeClass
 	public static void setupCryptos() throws Exception {
 		NotificationManager.start(null, Mockito.mock(ServerContainer.class));
-		user1Keystore = new File("user1.keystore");
-		user2Keystore = new File("user2.keystore");
-		
+		user1Keystore = File.createTempFile("user1","keystore");
+		user1Keystore.deleteOnExit();
+		user2Keystore = File.createTempFile("user2","keystore");
+		user2Keystore.deleteOnExit();
+
 		user1Keystore.delete();
 		user2Keystore.delete();
 		

--- a/host/src/test/java/org/area515/resinprinter/security/keystore/RendezvousExchange.java
+++ b/host/src/test/java/org/area515/resinprinter/security/keystore/RendezvousExchange.java
@@ -77,8 +77,8 @@ public class RendezvousExchange {
 		
 		RendezvousPipe pipe = new RendezvousPipe(wsPort);
 		
-		File user1Keystore = new File("user1.keystore");
-		File user2Keystore = new File("user2.keystore");
+		File user1Keystore = File.createTempFile("user1","keystore");
+		File user2Keystore = File.createTempFile("user2","keystore");
 		
 		user1Keystore.delete();
 		user2Keystore.delete();


### PR DESCRIPTION
Tests that rely on creating files now properly clean
them up.

closes #8